### PR TITLE
Tweak to rules regex to only match final square brackets

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var forbiddenSyntax = /F/;
 var goneSyntax = /G/;
 var typeSyntax = /T=([\w|\/]+,?)/;
 var hostSyntax =  /H=([^,]+)/;
-var flagSyntax = /\[(.*)\]$/;
+var flagSyntax = /\[([^\]]+)]$/;
 var partsSyntax = /\s+|\t+/g;
 var httpsSyntax = /^https/;
 var querySyntax = /\?(.*)/;

--- a/test/test.js
+++ b/test/test.js
@@ -454,4 +454,26 @@ describe('Connect-modrewrite', function() {
       expect(req.url).to.equal(url);
     });
   });
+
+  describe('only flags matched', function() {
+    it('should only match rules in the final square brackets', function() {
+      var middleware = modRewrite(['^/[a] /G [L]']);
+      var url = '/a';
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : url
+      };
+      var res = {
+        setHeader : function() {},
+        writeHead : sinon.spy(),
+        end : sinon.spy()
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/G');
+      res.writeHead.should.have.not.been.calledWith(410);
+    });
+  });
 });


### PR DESCRIPTION
If either the source or destination strings contain an opening square bracket, the current Rules regex will match the anything after the first square bracket.  Therefore, too much of the rule is considered when determining which action to take

e.g. for the rule "/a[z] /bG [L]" the Rules regex will match "[z] /bG [L]".  Then the "Gone" rule will match on the captial G in the destination string and rather than treating this as a standard rewrite, will try to return a 410 status code
