### PR TITLE
Query string support

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -476,4 +476,68 @@ describe('Connect-modrewrite', function() {
       res.writeHead.should.have.not.been.calledWith(410);
     });
   });
+
+  describe('Query string not included in comparison', function() {
+    it('should only consider the url path when determining a rule match', function() {
+      var middleware = modRewrite(['/a$ /b [L]']);
+      var url = '/a?b=c';
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : url
+      };
+      var res = {
+        setHeader : function() {},
+        writeHead : sinon.spy(),
+        end : sinon.spy()
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/b?b=c');
+    });
+  });
+
+  describe('QSA flag respected', function() {
+    it('should append the original request query string if QSA flag set', function() {
+      var middleware = modRewrite(['/pages/(.+) /page.php?page=$1 [QSA]']);
+      var url = '/pages/123?one=two';
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : url
+      };
+      var res = {
+        setHeader : function() {},
+        writeHead : sinon.spy(),
+        end : sinon.spy()
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/page.php?page=123&one=two');
+    });
+  });
+
+  describe('Original request query string dropped if QSA flag not set', function() {
+    it('should drop the original request query string if QSA flag not set', function() {
+      var middleware = modRewrite(['/pages/(.+) /page.php?page=$1 []']);
+      var url = '/pages/123?one=two';
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : url
+      };
+      var res = {
+        setHeader : function() {},
+        writeHead : sinon.spy(),
+        end : sinon.spy()
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/page.php?page=123');
+    });
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -519,6 +519,29 @@ describe('Connect-modrewrite', function() {
     });
   });
 
+  describe('QSA flag respected for redirect', function() {
+    it('should append the original request query string to redirect Location if QSA flag set', function() {
+      var middleware = modRewrite(['/pages/(.+) /page.php?page=$1 [R,QSA]']);
+      var url = '/pages/123?one=two';
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : url
+      };
+      var res = {
+        setHeader : function() {},
+        writeHead : sinon.spy(),
+        end : sinon.spy()
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      res.writeHead.should.have.been.calledWith(301, { Location : 'http://test.com/page.php?page=123&one=two'});
+      res.end.should.have.been.calledOnce;
+      res.end.should.have.been.calledAfter(res.writeHead);
+    });
+  });
+
   describe('Original request query string dropped if QSA flag not set', function() {
     it('should drop the original request query string if QSA flag not set', function() {
       var middleware = modRewrite(['/pages/(.+) /page.php?page=$1 []']);
@@ -537,6 +560,29 @@ describe('Connect-modrewrite', function() {
       var next = function() {};
       middleware(req, res, next);
       expect(req.url).to.equal('/page.php?page=123');
+    });
+  });
+
+  describe('Original request query string dropped if QSA flag not set for redirect', function() {
+    it('should drop the original request query string if QSA flag not set for redirect', function() {
+      var middleware = modRewrite(['/pages/(.+) /page.php?page=$1 [R]']);
+      var url = '/pages/123?one=two';
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : url
+      };
+      var res = {
+        setHeader : function() {},
+        writeHead : sinon.spy(),
+        end : sinon.spy()
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      res.writeHead.should.have.been.calledWith(301, { Location : 'http://test.com/page.php?page=123'});
+      res.end.should.have.been.calledOnce;
+      res.end.should.have.been.calledAfter(res.writeHead);
     });
   });
 


### PR DESCRIPTION
Warning: contains a breaking change

To bring this more inline with mod_rewrite, the regex should only be compared against the URL request path (i.e. excludes the query string)

I've also added support for the Query String Append (QSA) flag and followed mod_rewrites behaviour for handling query strings.
